### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ script:
   - bower install --production
   - npm run -s build
   - bower install
-  - npm -s test
 after_success:
-- >-
-  test $TRAVIS_TAG &&
-  git stash &&
-  echo $GITHUB_TOKEN | pulp login &&
-  echo y | pulp publish --no-push
+  - >-
+    test $TRAVIS_TAG &&
+    git stash &&
+    echo $GITHUB_TOKEN | pulp login &&
+    echo y | pulp publish --no-push

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/garyb/purescript-codec.git"
+    "url": "https://github.com/garyb/purescript-codec.git"
   },
   "ignore": [
     "**/.*",
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-transformers": "^4.0.0",
-    "purescript-profunctor": "^4.0.0"
+    "purescript-transformers": "^5.0.0",
+    "purescript-profunctor": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "build": "pulp build -- --censor-lib --strict"
   },
   "devDependencies": {
-    "pulp": "^12.0.0",
-    "purescript": "^0.12.0",
-    "purescript-psa": "^0.6.0",
-    "rimraf": "^2.6.2"
+    "pulp": "^15.0.0",
+    "purescript": "^0.14.0",
+    "purescript-psa": "^0.8.2",
+    "rimraf": "^3.0.0"
   }
 }

--- a/src/Data/Codec.purs
+++ b/src/Data/Codec.purs
@@ -6,7 +6,6 @@ import Control.Alternative (class Alt, class Alternative, class Plus, empty, (<|
 import Control.Monad.Reader (ReaderT(..), mapReaderT, runReaderT)
 import Control.Monad.Writer (Writer, writer, execWriter, runWriter)
 import Control.MonadPlus (class MonadPlus)
-import Control.MonadZero (class MonadZero)
 import Data.Functor.Invariant (class Invariant, imapF)
 import Data.Newtype (un)
 import Data.Profunctor (class Profunctor, dimap, lcmap)
@@ -14,6 +13,7 @@ import Data.Profunctor.Star (Star(..))
 import Data.Tuple (Tuple(..))
 
 -- | A general type for codecs.
+data GCodec :: (Type -> Type) -> (Type -> Type) -> Type -> Type -> Type
 data GCodec m n a b = GCodec (m b) (Star n a b)
 
 instance functorGCodec ∷ (Functor m, Functor n) ⇒ Functor (GCodec m n a) where
@@ -49,8 +49,6 @@ instance plusGCodec ∷ (Plus m, Plus n) ⇒ Plus (GCodec m n a) where
   empty = GCodec empty empty
 
 instance alternativeGCodec ∷ (Alternative m, Alternative n) ⇒ Alternative (GCodec m n a)
-
-instance monadZeroGCodec ∷ (MonadZero m, MonadZero n) ⇒ MonadZero (GCodec m n a)
 
 instance monadPlusGCodec ∷ (MonadPlus m, MonadPlus n) ⇒ MonadPlus (GCodec m n a)
 


### PR DESCRIPTION
Hi @garyb! This PR updates your Bower dependencies for PureScript 0.14. It also updates the repository url in your Bower file to match the PureScript registry.

If this looks good to you, you could cut a v4.0.0 release for `codec` and I can take care of updating it in package sets.