### PR TITLE
Make `Codec` much simpler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.*
 !/.gitignore
 !/.github
+!/.tidyrc.json
 /bower_components/
 /node_modules/
 /output/

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "always",
+  "width": null
+}

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-transformers": "^6.0.0",
-    "purescript-profunctor": "^6.0.0"
+    "purescript-profunctor": "^6.0.0",
+    "purescript-bifunctors": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "pulp build -- --censor-lib --strict"
+    "build": "pulp build -- --censor-lib --strict && purs-tidy check src"
   },
   "devDependencies": {
-    "pulp": "^16.0.0",
-    "purescript": "^0.15.0",
+    "pulp": "^16.0.2",
+    "purescript": "^0.15.6",
     "purescript-psa": "^0.8.2",
-    "rimraf": "^3.0.0"
+    "purs-tidy": "^0.9.2",
+    "rimraf": "^3.0.2"
   }
 }

--- a/src/Data/Codec.purs
+++ b/src/Data/Codec.purs
@@ -25,7 +25,7 @@ instance (Applicative m, Monoid b) ⇒ Applicative (Codec m a b c) where
 instance Functor m ⇒ Profunctor (Codec m a b) where
   dimap f g (Codec h i) = Codec (map g <<< h) (map g <<< i <<< f)
 
-codec ∷ ∀ m a b d. (a → m d) → (d → b) → Codec m a b d d
+codec ∷ ∀ m a b c. (a → m c) → (c → b) → Codec m a b c c
 codec f g = Codec f (\b → Tuple (g b) b)
 
 type Codec' m a b = Codec m a a b b


### PR DESCRIPTION
- Removes `GCodec` entirely and inlines the `Reader`/`Star`/`Writer` aspects of the previous version.
- Removed some instances that I'm not convinced were correct.
- Removed `mapCodec` for now at least. It was just one of many possible mapping patterns that aren't handled by the instances, and now it's much easier to construct codecs directly it didn't seem worth promoting this one particular case since it can be defined fairly trivially as needed.
- `BasicCodec` has become `Codec'` ala optics, routing-duplex. Correspondingly, `basicCodec` constructor function is now `codec'`
- Added a `codec` constructor for creating `Codec a b c c`s, which seems to be very common.